### PR TITLE
Add support for utf8 pilot names and avoid html injection attacks

### DIFF
--- a/dblogon.php
+++ b/dblogon.php
@@ -1,4 +1,7 @@
 <?php
     //open connection to mysql db
     $connection = mysqli_connect("localhost","","","tvs") or die("Error " . mysqli_error($connection));
+
+	// Use utf8 character set
+	mysqli_set_charset ($connection, 'utf8mb4') or die('Could not set charset');
 ?>

--- a/detail.php
+++ b/detail.php
@@ -7,11 +7,11 @@
 include 'functions.php';
 
 if(isset($_REQUEST['pilot'])){
-    $pilot = $connection->real_escape_string($_REQUEST['pilot']);
+    $pilot = $_REQUEST['pilot'];
     $turn = getTurn();
     $date = date("Y-m-d H:i:s"); 
     $ts = getLastDBUpdate();
-    echo "<h2>Pilot: $pilot history</h2>";
+    echo "<h2>Pilot: ".htmlentities($pilot, ENT_QUOTES, 'UTF-8')." history</h2>";
 
     $history = getPilotHistoryFromDatabase($pilot);
     $current_pilots = getPilots();
@@ -21,6 +21,10 @@ if(isset($_REQUEST['pilot'])){
 }
 ?>
 <script type="text/javascript">
-var table = new Tabulator("#pilots-table", {width:"500px",layout:"fitDataTable", });
+var table = new Tabulator("#pilots-table", {width:"500px",layout:"fitDataTable", 
+columns:[
+{title:"Turn", field:"turn", formatter:"number"},
+{title:"Rank", field:"number", formatter:"number"},
+{title:"Pilot", field:"url_label", formatter:"html"},
+]});
 </script>
-

--- a/dump.py
+++ b/dump.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
   # `online` tinyint(1) DEFAULT '0',
   # `ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   # `turn` int(4) NOT NULL
-# ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+# ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 class TVSDump():
 
@@ -41,13 +41,14 @@ class TVSDump():
         self.db = MySQLdb.connect(host="localhost",    # your host, usually localhost
                                  user="",         # your username
                                  passwd="",  # your password
-                                 db="tvs")        # name of the data base
+                                 db="tvs",        # name of the data base
+                                 charset="utf8mb4")
         cursor = self.db.cursor()
         rank=1
         for value in data['rankings_pilots']:
             #print value['tvs_username'].encode('utf-8').decode('cp1252')
             sql = "INSERT INTO `tvs` (`rank`,`tvs_username`, `legion`, `level`, `hp`, `maxhp`, `ship`, `score`, `kills`, `deaths`, `online`, `turn`) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
-            cursor.execute(sql, (rank,value['tvs_username'].encode('utf-8').decode('cp1252'),int(value['legion']),int(value['level']),int(value['hp']),int(value['maxhp']),int(value['ship']),int(value['score']),int(value['kills']),int(value['deaths']),int(value['online']),tick))
+            cursor.execute(sql, (rank,value['tvs_username'],int(value['legion']),int(value['level']),int(value['hp']),int(value['maxhp']),int(value['ship']),int(value['score']),int(value['kills']),int(value['deaths']),int(value['online']),tick))
             rank += 1
         cursor.execute('COMMIT')
         self.db.close()

--- a/functions.php
+++ b/functions.php
@@ -75,12 +75,13 @@ function getLastDBUpdate() {
 
 function getPilotHistoryFromDatabase($pilot) {
     global $connection;
+    $pilot = $connection->real_escape_string($pilot);
     //fetch table rows from mysql db
     $sql = "select * from tvs where tvs_username = '$pilot'";
     $result = mysqli_query($connection, $sql) or die("Error in Selecting " . mysqli_error($connection));
 
     //create an array
-    $pilots = array();
+    $history = array();
     while($row =mysqli_fetch_assoc($result))
     {
         $history[] = $row;
@@ -150,7 +151,7 @@ function createHistoryHtmlTable($pilot, $data, $json_data) {
             $tablehtml="<tr>
                 <td>".$value['turn']."</td>
                 <td>".$value['rank']."</td>
-                <td>".$value['tvs_username']."</td>
+                <td>".htmlentities($value['tvs_username'], ENT_QUOTES, 'UTF-8')."</td>
                 <td>".$legions[$value['legion']]."</td>
                 <td>".$value['level']."</td>
                 <td>".$value['hp']."</td>
@@ -182,7 +183,7 @@ function createHistoryHtmlTable($pilot, $data, $json_data) {
     $tablehtml="<tr>
                 <td>".$turn."</td>
                 <td>".$rank."</td>
-                <td>".$value['tvs_username']."</td>
+                <td>".htmlentities($value['tvs_username'], ENT_QUOTES, 'UTF-8')."</td>
                 <td>".$legions[$value['legion']]."</td>
                 <td>".$value['level']."</td>
                 <td>".$value['hp']."</td>
@@ -244,7 +245,7 @@ function createRankingHtmlTable($data, $db_data) {
             }
             $tablehtml.="<tr>
                 <td>".$rank."</td>
-                <td>".$value['tvs_username']."</td>
+                <td><a href='detail.php?pilot=".urlencode($value['tvs_username'])."'>".htmlentities($value['tvs_username'], ENT_QUOTES, 'UTF-8')."</a></td>
                 <td>".$legions[$value['legion']]."</td>
                 <td>".$value['level']."</td>
                 <td>".$value['hp']."</td>

--- a/pilots.php
+++ b/pilots.php
@@ -18,7 +18,7 @@ echo createRankingHtmlTable($pilots,$dbpilots);
 <script type="text/javascript">
 var table = new Tabulator("#pilots-table", {width:"500px",layout:"fitDataTable", columns:[
 {title:"Rank", field:"number", formatter:"number"},
-{title:"Pilot", field:"url_label", formatter:"link", formatterParams:{url:function(cell){return "detail.php?pilot=" + cell.getValue();}}},
+{title:"Pilot", field:"url_label", formatter:"html"},
  ],});
 </script>
 


### PR DESCRIPTION
A wide gamut of unicode characters are permitted in tvs user names and therefore utf8 database should be used. Also necessary to escape html entities to avoid usernames containing special characters like "<script>" causing issues